### PR TITLE
Change steerRateCost

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -77,7 +77,7 @@ class CarInterface(CarInterfaceBase):
     ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
     ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.00]]
     ret.lateralTuning.pid.kf = 0.00004   # full torque for 20 deg at 80mph means 0.00007818594
-    ret.steerRateCost = 1.0
+    ret.steerRateCost = 0.5
     ret.steerActuatorDelay = 0.1  # Default delay, not measured yet
     ret.enableGasInterceptor = 0x201 in fingerprint[0]
     # # Check for Electronic Parking Brake


### PR DESCRIPTION
0.5 changes the increments of the steering wheel's ability to accurately adjust for changes in trajectory. I.e a car can now move the steering wheel in 10 small increments as opposed to 7 small increments for the same change in trajectory. 

0.5 is the preferred value over stock and will not cause hyperactivity in steering (e.g too many small steering wheel movements)