### PR TITLE
fix suburban mass

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -241,7 +241,7 @@ class CarInterface(CarInterfaceBase):
     elif candidate == CAR.SUBURBAN:
       ret.minEnableSpeed = -1. # engage speed is decided by pcmFalse
       ret.minSteerSpeed = -1 * CV.MPH_TO_MS
-      ret.mass = 1278. + STD_CARGO_KG
+      ret.mass = 2729. + STD_CARGO_KG
       ret.wheelbase = 3.302
       ret.steerRatio = 16.3 # COPIED FROM SILVERADO
       ret.centerToFront = ret.wheelbase * 0.49


### PR DESCRIPTION
fixing max of suburban. Was at half the correct value. Could have been a source of tuning difficulty considering the number of places mass comes into play in vehicle model.