### PR TITLE
Brightness control: tap DM icon

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -63,6 +63,15 @@ void HomeWindow::showDriverView(bool show) {
 }
 
 void HomeWindow::mousePressEvent(QMouseEvent* e) {
+ // screen dim button (dm face icon)
+  if (uiState()->scene.started && uiState()->scene.screen_dim_touch_rect.ptInRect(e->x(), e->y())){
+    uiState()->scene.screen_dim_mode -= 1;
+    if (uiState()->scene.screen_dim_mode < 0){
+      uiState()->scene.screen_dim_mode = uiState()->scene.screen_dim_mode_max;
+    }
+    return;
+  }
+  
   // Handle sidebar collapsing
   if (onroad->isVisible() && (!sidebar->isVisible() || e->x() > sidebar->width())) {
     sidebar->setVisible(!sidebar->isVisible() && !onroad->isMapVisible());

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -66,10 +66,27 @@ void OnroadWindow::updateState(const UIState &s) {
   }
 }
 
+// Uses larger rect to check for presses for the purpose of ignoring input and not loading nav view
+bool ptInBiggerRect(Rect const & r, QMouseEvent* e){
+#ifdef ENABLE_MAPS
+  Rect br = {r.x - r.w / 5, r.y - r.h / 5, 7 * r.w / 5, 7 * r.h / 5};
+  return br.ptInRect(e->x(), e->y());
+#else
+  return false;
+#endif
+}
+
 void OnroadWindow::mousePressEvent(QMouseEvent* e) {
   if (map != nullptr) {
     bool sidebarVisible = geometry().x() > 0;
-    map->setVisible(!sidebarVisible && !map->isVisible());
+    if (!sidebarVisible){
+      // prevent nav from showing if a tappable ui element has been tapped
+      bool ignorePress = false;
+      ignorePress = ignorePress || ptInBiggerRect(uiState()->scene.screen_dim_touch_rect, e);
+      if (!ignorePress){
+        map->setVisible(!map->isVisible());
+      }
+    }
   }
   // propagation event to parent(HomeWindow)
   QWidget::mousePressEvent(e);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -27,6 +27,17 @@ typedef cereal::CarControl::HUDControl::AudibleAlert AudibleAlert;
 const float y_offset = Hardware::EON() ? 0.0 : 150.0;
 const float ZOOM = Hardware::EON() ? 2138.5 : 2912.8;
 
+typedef struct Rect {
+  int x, y, w, h;
+  int centerX() const { return x + w / 2; }
+  int centerY() const { return y + h / 2; }
+  int right() const { return x + w; }
+  int bottom() const { return y + h; }
+  bool ptInRect(int px, int py) const {
+    return px >= x && px < (x + w) && py >= y && py < (y + h);
+  }
+} Rect;
+
 struct Alert {
   QString text1;
   QString text2;
@@ -93,6 +104,16 @@ typedef struct {
 typedef struct UIScene {
   mat3 view_from_calib;
   cereal::PandaState::PandaType pandaType;
+
+  // brightness control
+  float screen_dim_modes_v[3] = {0.01, 0.5, 1.}; // add more levels as desired
+  int screen_dim_mode_max = sizeof(screen_dim_modes_v) / sizeof(screen_dim_modes_v[0]) - 1;
+  int screen_dim_mode_cur = screen_dim_mode_max;
+  int screen_dim_mode = screen_dim_mode_max;
+  int screen_dim_mode_last = screen_dim_mode_max;
+  float screen_dim_fade = -1., screen_dim_fade_last_t = 0., screen_dim_fade_step = 1;
+  float screen_dim_fade_dur_up = 0.5, screen_dim_fade_dur_down = 2.;
+  Rect screen_dim_touch_rect;
 
   // modelV2
   float lane_line_probs[4];


### PR DESCRIPTION
Adds on-road brightness control by tapping the DM icon (the bottom-left screen corner). 

- Tap cycles between low(1)/medium(50)/stock(100) brightness modes.
- Changes are smoothly faded
- Safety first: when lower then stock brightness, warning and error alerts will raise the brightness automatically, then smoothly fades back down.
