### PR TITLE
Pr gm long pitch compensation

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -59,7 +59,7 @@ class CarController:
       idx = (CS.lka_steering_cmd_counter + 1) % 4
 
       can_sends.append(gmcan.create_steering_control(self.packer_pt, CanBus.POWERTRAIN, apply_steer, idx, CC.latActive))
-
+    
     if self.CP.openpilotLongitudinalControl:
       # Gas/regen, brakes, and UI commands - all at 25Hz
       if self.frame % 4 == 0:
@@ -69,11 +69,11 @@ class CarController:
           self.apply_brake = 0
         else:
           if self.CP.carFingerprint in EV_CAR:
-            self.apply_gas = int(round(interp(actuators.accel, self.params.EV_GAS_LOOKUP_BP, self.params.GAS_LOOKUP_V)))
-            self.apply_brake = int(round(interp(actuators.accel, self.params.EV_BRAKE_LOOKUP_BP, self.params.BRAKE_LOOKUP_V)))
+            self.apply_gas = int(round(interp(actuators.accelPitchCompensated, self.params.EV_GAS_LOOKUP_BP, self.params.GAS_LOOKUP_V)))
+            self.apply_brake = int(round(interp(actuators.accelPitchCompensated, self.params.EV_BRAKE_LOOKUP_BP, self.params.BRAKE_LOOKUP_V)))
           else:
-            self.apply_gas = int(round(interp(actuators.accel, self.params.GAS_LOOKUP_BP, self.params.GAS_LOOKUP_V)))
-            self.apply_brake = int(round(interp(actuators.accel, self.params.BRAKE_LOOKUP_BP, self.params.BRAKE_LOOKUP_V)))
+            self.apply_gas = int(round(interp(actuators.accelPitchCompensated, self.params.GAS_LOOKUP_BP, self.params.GAS_LOOKUP_V)))
+            self.apply_brake = int(round(interp(actuators.accelPitchCompensated, self.params.BRAKE_LOOKUP_BP, self.params.BRAKE_LOOKUP_V)))
 
         idx = (self.frame // 4) % 4
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -104,6 +104,9 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kiV = [0.]
       ret.lateralTuning.pid.kf = 1.  # get_steer_feedforward_volt()
       ret.steerActuatorDelay = 0.2
+      
+      ret.longitudinalActuatorDelayLowerBound = 0.41
+      ret.longitudinalActuatorDelayUpperBound = 0.41
 
     elif candidate == CAR.MALIBU:
       ret.mass = 1496. + STD_CARGO_KG


### PR DESCRIPTION
Adds pitch compensation to be used in cars that use gas/brake control, where the command specifies an amount of acceleration force rather than an amount of acceleration relative to the road.

To allow this to account for longitudinal actuator delay to allow for smoothing of the pitch signal, future model pitch is used to create a smoothed, predictive pitch.

The result is a complete elimination of long error due to pitch changes. In the following image the plots on the left are without pitch compensation, and on the right with pitch compensation. 

![Screen Shot 2022-08-17 at 3 16 49 PM](https://user-images.githubusercontent.com/7284371/185260603-91326ad7-0227-4c03-92c9-1dcd731b0e52.png)


See that as I climb up the stepped hill (pitch changing between 0 and ~12% grade), the pitchFutureLone (right side, second plot from top, orange line) predicts the liveParams pitch by ~0.4s, which is the value set for longitudinalActuatorDelayLowerBound (and upper bound), so it's predicting by the correct amount.

While there are large deviations between target and actual acceleration (fourth plot from top, left side) without pitch compensation, the pitch-induced error is completely removed on the right (error stays within ±0.05m/s^2 vs ±0.25m/s^2).
Also the with pitch compensation speed stays within 0±0.1m/s^2 compared to ±0.4m/s^2 (top plot). 

Here's another image showing data where I descend down the same stepped hill. Again, with pitch compensation, the speed and acceleration oscillations due to changing pitch are completely removed.

![Screen Shot 2022-08-17 at 3 12 35 PM](https://user-images.githubusercontent.com/7284371/185260625-57befcbb-1b73-46ed-98c3-32ea2c6ff5b6.png)



This PR includes three other PRs to 1) [add liveParams pitch](https://github.com/commaai/openpilot/pull/25466), 2) [add liveParams future predicted pitch based on long actuator delay](https://github.com/opgm/openpilot/pull/76), and 3) to [add calculation of pitch-compensated acceleration, saved to actuators.accelPitchCompensated](https://github.com/opgm/openpilot/pull/77).