### PR TITLE
Fixed gap adjust to change personalities

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -123,6 +123,10 @@ struct CarEvent @0x9b1657f34caf3ad3 {
 
     pedalInterceptorNoBrake @122;
 
+    personalityRelaxed @123;
+    personalityStandard @124;
+    personalityAggressive @125;
+
     radarCanErrorDEPRECATED @15;
     communityFeatureDisallowedDEPRECATED @62;
     radarCommIssueDEPRECATED @67;

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -401,6 +401,12 @@ class CarInterfaceBase(ABC):
       elif not cs_out.cruiseState.enabled:
         events.add(EventName.pcmDisable)
 
+    if self.CS.personality_updated != -1:
+      personality_events = [EventName.personalityAggressive, EventName.personalityStandard, EventName.personalityRelaxed]
+      events.add(personality_events[self.CS.personality_updated])
+      self.CS.personality_updated = -1
+
+
     return events
 
 
@@ -425,6 +431,8 @@ class CarStateBase(ABC):
     self.params = Params()
     self.car_fingerprint = CP.carFingerprint
     self.out = car.CarState.new_message()
+
+    self.personality_updated = -1
 
     # PFEIFER - AOL {{
     self.lateral_allowed = False
@@ -509,12 +517,13 @@ class CarStateBase(ABC):
     return bool(left_blinker_stalk or self.left_blinker_cnt > 0), bool(right_blinker_stalk or self.right_blinker_cnt > 0)
 
   def update_personality(self, distance_button_pressed: bool) -> None:
-    self.distance_button_timer = self.distance_button_timer + 1 if distance_button_pressed else 0
     if self.distance_button_timer == CRUISE_LONG_PRESS:
       put_bool_nonblocking("ExperimentalMode", not self.params.get_bool("ExperimentalMode"))
-    elif not distance_button_pressed and self.distance_button_timer > 0:  # falling edge
+    elif not distance_button_pressed and self.distance_button_timer > 0 and self.distance_button_timer < CRUISE_LONG_PRESS:  # falling edge
       self.longitudinal_personality = (self.longitudinal_personality - 1) % 3
       put_nonblocking("LongitudinalPersonality", str(self.longitudinal_personality))
+      self.personality_updated = self.longitudinal_personality
+    self.distance_button_timer = self.distance_button_timer + 1 if distance_button_pressed else 0
 
   @staticmethod
   def parse_gear_shifter(gear: Optional[str]) -> car.CarState.GearShifter:

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -988,6 +988,30 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
       Priority.HIGH, VisualAlert.wrongGear, AudibleAlert.promptRepeat, 4.),
     ET.NO_ENTRY: NoEntryAlert("Shift To L To Use Pedal Interceptor"),
   },
+
+  EventName.personalityRelaxed: {
+    ET.PERMANENT: Alert(
+      "Relaxed",
+      "",
+      AlertStatus.normal, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, 2.0),
+  },
+
+  EventName.personalityStandard: {
+    ET.PERMANENT: Alert(
+      "Standard",
+      "",
+      AlertStatus.normal, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, 2.0),
+  },
+
+  EventName.personalityAggressive: {
+    ET.PERMANENT: Alert(
+      "Aggresive",
+      "",
+      AlertStatus.normal, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, 2.0),
+  },
 }
 
 

--- a/selfdrive/ui/qt/widgets/controls.h
+++ b/selfdrive/ui/qt/widgets/controls.h
@@ -246,6 +246,19 @@ public:
     });
   }
 
+  void refresh() {
+    int value = atoi(params.get(key).c_str());
+    int i = 0;
+    for (auto btn : button_group->buttons()) {
+      btn->setChecked(i == value);
+      i++;
+    }
+  }
+
+  void showEvent(QShowEvent *event) override {
+    refresh();
+  }
+
   void setEnabled(bool enable) {
     for (auto btn : button_group->buttons()) {
       btn->setEnabled(enable);


### PR DESCRIPTION
Fixed using the gap adjust button to cycle between driving personalities. There was a small logic error in the existing code. The Toggles menu will now also correctly update based on the selected personality, and cycling personalities will display a notification indicating the currently selected personality.