### PR TITLE
Fix Redneck and Pedal

### DIFF
--- a/selfdrive/car/cruise.py
+++ b/selfdrive/car/cruise.py
@@ -47,7 +47,7 @@ class VCruiseHelper:
     self.v_cruise_kph_last = self.v_cruise_kph
 
     if CS.cruiseState.available:
-      if not self.CP.pcmCruise:
+      if self.gm_cc_only or not self.CP.pcmCruise:
         # if stock cruise is completely disabled, then we can use our own set speed logic
         self._update_v_cruise_non_pcm(CS, enabled, is_metric)
         self.v_cruise_cluster_kph = self.v_cruise_kph


### PR DESCRIPTION
Fixes:
Pedal Long cancels cruise
Redneck engages properly due to a check that ensures openpilot is already active before sending cancel
Redneck works properly / Split vcruise for cclong and updated timing config. 